### PR TITLE
Fix: don't throw when setup.py doesn't exist and generate one automatically if needed

### DIFF
--- a/vpip/dependency.py
+++ b/vpip/dependency.py
@@ -73,7 +73,7 @@ class ProdUpdater(Updater):
             text = self.file.read_text("utf8")
         except OSError:
             return
-        self.indent = detect_indent(text)
+        self.indent = detect_indent(text) or self.indent
         self.config.read_string(text)
         
     def get_requirements(self):

--- a/vpip/dependency.py
+++ b/vpip/dependency.py
@@ -66,7 +66,7 @@ class ProdUpdater(Updater):
         self.file = Path("setup.cfg")
         self.file_py = self.file.with_suffix(".py")
         self.config = ConfigUpdater()
-        self.indent = None
+        self.indent = "  " # default to 2 spaces indent?
         
     def read(self):
         try:

--- a/vpip/pip_api.py
+++ b/vpip/pip_api.py
@@ -1,6 +1,7 @@
 """``pip`` command API."""
 
 import json
+import pathlib
 import re
 from argparse import Namespace
 from subprocess import CalledProcessError
@@ -45,7 +46,9 @@ def install_requirements(file="requirements.txt"):
     
 def install_editable():
     """Install the current cwd as editable package."""
-    execute_pip("install -e .")
+    setup = pathlib.Path("setup.py")
+    if setup.exists():
+        execute_pip("install -e .")
     
 def uninstall(packages):
     """Uninstall packages.

--- a/vpip/pip_api.py
+++ b/vpip/pip_api.py
@@ -55,6 +55,8 @@ def uninstall(packages):
     
     :arg list[str] package: Package name.
     """
+    if not packages:
+        return
     execute_pip("uninstall -y {}".format(" ".join(packages)))
     
 def show(packages, verbose=False):
@@ -68,6 +70,9 @@ def show(packages, verbose=False):
     This function uses ``pip show`` under the hood. Property name is generated
     by :func:`case_conversion.snakecase`.
     """
+    if not packages:
+        return []
+        
     cmd = "show"
     if verbose:
         cmd += " --verbose"


### PR DESCRIPTION
Fixes #24